### PR TITLE
use mentions in the channel topics for easier navagation.

### DIFF
--- a/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
+++ b/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
@@ -53,24 +53,33 @@ namespace ModixTranslator.HostedServices
 
             var fromLangName = $"{safeLang}-to-{safeGuildLang}";
             var toLangName = $"{safeGuildLang}-to-{safeLang}";
-            var fromLangTopic = await _translation.GetTranslation(guildLang, lang, $"Responses will be translated to {guildLang} and posted in this channel's pair `#{fromLangName}`");
-            var toLangTopic = $"Responses will be translated to {lang} and posted in this channel's pair `#{toLangName}`";
 
             var fromLangChannel = await guild.CreateTextChannelAsync(fromLangName, p =>
             {
                 p.CategoryId = category.Id;
-                p.Topic = fromLangTopic;
             });
 
-            var ToLangChannel = await guild.CreateTextChannelAsync(toLangName, p =>
+            var toLangChannel = await guild.CreateTextChannelAsync(toLangName, p =>
             {
                 p.CategoryId = category.Id;
-                p.Topic = toLangTopic;
             });
+
+            await fromLangChannel.ModifyAsync(async p =>
+            {
+                p.Topic = await _translation.GetTranslation(guildLang, lang,
+                    $"Responses will be translated to {guildLang} and posted in this channel's pair") + $"<#{toLangChannel.Id}>";
+            });
+
+            await toLangChannel.ModifyAsync(p =>
+            {
+                p.Topic =
+                    $"Responses will be translated to {lang} and posted in this channel's pair <#{fromLangChannel.Id}>";
+            });
+            
             pair = new ChannelPair
             {
                 TranslationChannel = fromLangChannel,
-                StandardLangChanel = ToLangChannel
+                StandardLangChanel = toLangChannel
             };
 
             if (!_channelPairs.TryAdd(safeLang, pair))

--- a/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
+++ b/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
@@ -67,13 +67,13 @@ namespace ModixTranslator.HostedServices
             await fromLangChannel.ModifyAsync(async p =>
             {
                 p.Topic = await _translation.GetTranslation(guildLang, lang,
-                    $"Responses will be translated to {guildLang} and posted in this channel's pair") + $"<#{toLangChannel.Id}>";
+                    $"Responses will be translated to {guildLang} and posted in this channel's pair {toLangChannel.Mention}");
             });
 
             await toLangChannel.ModifyAsync(p =>
             {
                 p.Topic =
-                    $"Responses will be translated to {lang} and posted in this channel's pair <#{fromLangChannel.Id}>";
+                    $"Responses will be translated to {lang} and posted in this channel's pair {fromLangChannel.Mention}";
             });
             
             pair = new ChannelPair


### PR DESCRIPTION
This uses the discord mention syntax to allow for one click navigation from the topic. It's a very simple change.

Note: I wasn't able to test this due to azure not allowing me to sign up.