### PR TITLE
Fix code blocks disappearing from translations

### DIFF
--- a/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
+++ b/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
@@ -16,7 +16,6 @@ namespace ModixTranslator.HostedServices
 {
     public class TranslatorHostedService : ITranslatorHostedService
     {
-        private const int ChunkSize = 1024;
         private readonly ILogger<TranslatorHostedService> _logger;
         private readonly ITranslationService _translation;
         private readonly IBotService _bot;
@@ -210,9 +209,10 @@ namespace ModixTranslator.HostedServices
                     var guildLocal = translation.GuildLocal;
                     var foreign = translation.Foreign;
 
+                    const int fieldLength = 1024;
                     var lengthIsBrief = 
-                        guildLocal.Text.Length < ChunkSize && 
-                        foreign.Text.Length < ChunkSize;
+                        guildLocal.Text.Length < fieldLength && 
+                        foreign.Text.Length < fieldLength;
                     var hasCodeBlocks = TranslationService.CodeBlockPattern.IsMatch(translation.Translated.Text);
 
                     if (lengthIsBrief && !hasCodeBlocks)
@@ -224,8 +224,8 @@ namespace ModixTranslator.HostedServices
                     else
                     {
                         embed
-                            .AddChunks(guildLocal.Text.ChunkUpTo(ChunkSize), guildLocal.Language)
-                            .AddChunks(foreign.Text.ChunkUpTo(ChunkSize), foreign.Language);
+                            .AddChunks(guildLocal.Text.ChunkUpTo(fieldLength), guildLocal.Language)
+                            .AddChunks(foreign.Text.ChunkUpTo(fieldLength), foreign.Language);
                     }
 
                     if (message.Attachments.Any())
@@ -259,7 +259,7 @@ namespace ModixTranslator.HostedServices
             var translation = await _translation.GetTranslation(from, to, message.Content);
             translation.Type = type;
 
-            foreach (var chunk in $"{Format.Bold(username)}: {translation.Translated.Text}".ChunkUpTo(ChunkSize))
+            foreach (var chunk in $"{Format.Bold(username)}: {translation.Translated.Text}".ChunkUpTo(2000))
             {
                 await targetChannel.SendMessageAsync(chunk);
             }

--- a/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
+++ b/src/ModixTranslator/HostedServices/TranslatorHostedService.cs
@@ -210,9 +210,12 @@ namespace ModixTranslator.HostedServices
                     var foreign = translation.Foreign;
 
                     const int chunkSize = 1024;
-                    var lengthIsBrief = guildLocal.Text.Length < chunkSize && foreign.Text.Length < chunkSize;
+                    var lengthIsBrief = 
+                        guildLocal.Text.Length < chunkSize && 
+                        foreign.Text.Length < chunkSize;
+                    var hasCodeBlocks = TranslationService.CodeBlockPattern.IsMatch(translation.Translated.Text);
 
-                    if (lengthIsBrief)
+                    if (lengthIsBrief && !hasCodeBlocks)
                     {
                         embed
                             .AddField(guildLocal.Language, guildLocal.Text, true)
@@ -223,13 +226,6 @@ namespace ModixTranslator.HostedServices
                         embed
                             .AddChunks(guildLocal.Text.ChunkUpTo(chunkSize), guildLocal.Language)
                             .AddChunks(foreign.Text.ChunkUpTo(chunkSize), foreign.Language);
-                    }
-
-                    if (translation.CodeBlocks.Any())
-                    {
-                        // Code blocks without any newline or space in between each other
-                        // are more compactly spaced
-                        embed.WithDescription(string.Join("", translation.CodeBlocks));
                     }
 
                     if (message.Attachments.Any())

--- a/src/ModixTranslator/Models/Translator/Translation.cs
+++ b/src/ModixTranslator/Models/Translator/Translation.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace ModixTranslator.Models.Translator
+﻿namespace ModixTranslator.Models.Translator
 {
     public class Translation
     {
@@ -13,12 +10,10 @@ namespace ModixTranslator.Models.Translator
 
         private readonly LocalText _original;
 
-        public Translation((string lang, string text) from, (string lang, string text) to,
-            IEnumerable<string>? codeBlocks = null)
+        public Translation((string lang, string text) from, (string lang, string text) to)
         {
             _original = new LocalText(from.lang, from.text);
             Translated = new LocalText(to.lang, to.text);
-            CodeBlocks = codeBlocks ?? Enumerable.Empty<string>();
         }
 
         public LocalText GuildLocal => Type == TranslationType.GuildLocale ? Translated : _original;
@@ -28,7 +23,5 @@ namespace ModixTranslator.Models.Translator
         public LocalText Translated { get; }
 
         public TranslationType Type { get; set; }
-
-        public IEnumerable<string> CodeBlocks { get; set; }
     }
 }

--- a/src/ModixTranslator/Services/TranslationService.cs
+++ b/src/ModixTranslator/Services/TranslationService.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using ModixTranslator.HostedServices;
-using ModixTranslator.Models.TranslationService;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -11,32 +8,40 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModixTranslator.HostedServices;
+using ModixTranslator.Models.TranslationService;
 using ModixTranslator.Models.Translator;
 
 namespace ModixTranslator.Behaviors
 {
     public class TranslationService : ITranslationService
     {
-        private readonly ILogger<TranslationService> _logger;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<TranslationService> _logger;
         private readonly ITranslationTokenProvider _tokenProvider;
+
+        //                                     matches `text` or <mention/emoji>
+        private readonly Regex inlinePattern = new Regex(@"`.*?`|<(@[!&]|#|a?:.+?:)[0-9]{17,19}>",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+
+        private readonly Regex keyScrubber = new Regex(@"\D", RegexOptions.Compiled);
 
         private readonly JsonSerializerOptions options = new JsonSerializerOptions
         {
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
-        //                                     matches `text` or <mention/emoji>
-        private readonly Regex inlinePattern = new Regex(@"`.*?`|<(@[!&]|#|a?:.+?:)[0-9]{17,19}>", RegexOptions.Singleline | RegexOptions.Compiled);
-        private readonly Regex codeBlockPattern = new Regex("```.*?```", RegexOptions.Singleline | RegexOptions.Compiled);
-        private readonly Regex keyScrubber = new Regex(@"\D", RegexOptions.Compiled);
-
-        public TranslationService(ILogger<TranslationService> logger, IHttpClientFactory httpClientFactory, ITranslationTokenProvider tokenProvider)
+        public TranslationService(ILogger<TranslationService> logger, IHttpClientFactory httpClientFactory,
+            ITranslationTokenProvider tokenProvider)
         {
             _logger = logger;
             _httpClientFactory = httpClientFactory;
             _tokenProvider = tokenProvider;
         }
+
+        public static Regex CodeBlockPattern { get; } =
+            new Regex("```.*?```", RegexOptions.Singleline | RegexOptions.Compiled);
 
         public async Task<bool> IsLangSupported(string lang)
         {
@@ -47,117 +52,100 @@ namespace ModixTranslator.Behaviors
         public async Task<SupportedLanguageResponse> GetSupportedLanguages()
         {
             using var client = _httpClientFactory.CreateClient();
-            var supportedResponse = await client.GetAsync("https://api.cognitive.microsofttranslator.com/languages?api-version=3.0&scope=translation");
+            var supportedResponse =
+                await client.GetAsync(
+                    "https://api.cognitive.microsofttranslator.com/languages?api-version=3.0&scope=translation");
             if (!supportedResponse.IsSuccessStatusCode)
             {
                 _logger.LogError("Unable to determine if a language is supported");
                 return new SupportedLanguageResponse();
             }
+
             var responseText = await supportedResponse.Content!.ReadAsStringAsync();
 
             var response = JsonSerializer.Deserialize<SupportedLanguageResponse>(responseText, options)!;
             return response!;
         }
 
-    public async Task<Translation> GetTranslation(string? from, string to, string text)
-    {
-        _logger.LogDebug($"Translating {text} from {from ?? "auto"} to {to}");
-
-        string translated;
-
-        var strippedText = text;
-        var codeBlocks = StripCodeBlocksFromText(ref strippedText);
-
-        try
+        public async Task<Translation> GetTranslation(string? from, string to, string text)
         {
-            var inlined = StripInlinedFromText(ref strippedText);
-            var client = _httpClientFactory.CreateClient("translationClient");
-            var token = _tokenProvider.Token;
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            client.BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com/");
+            _logger.LogDebug($"Translating {text} from {from ?? "auto"} to {to}");
 
-            var url = $"translate?api-version=3.0&to={to}";
+            string translated;
 
-            if (!string.IsNullOrWhiteSpace(from))
+            var strippedText = text;
+            var codeBlocks = StripText(ref strippedText, CodeBlockPattern);
+            var inlined = StripText(ref strippedText, inlinePattern);
+            try
             {
-                url += $"&from={from}";
+                var client = _httpClientFactory.CreateClient("translationClient");
+                var token = _tokenProvider.Token;
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                client.BaseAddress = new Uri("https://api.cognitive.microsofttranslator.com/");
+
+                var url = $"translate?api-version=3.0&to={to}";
+
+                if (!string.IsNullOrWhiteSpace(from)) url += $"&from={from}";
+
+                var requestBody = JsonSerializer.Serialize(new[] { new TranslationRequest(strippedText) }, options);
+                var response = await client.PostAsync(url,
+                    new StringContent(requestBody, Encoding.UTF8, "application/json"));
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    translated = text;
+                    var body = await response.Content!.ReadAsStringAsync();
+                    throw new InvalidOperationException(
+                        $"Unable to translate. Service returned {response.StatusCode}: {body}");
+                }
+
+                var json = await response.Content!.ReadAsStringAsync();
+                var translationResponse = JsonSerializer.Deserialize<List<TranslationResponse>>(json, options);
+                translationResponse = translationResponse ??
+                                      throw new InvalidOperationException("Response is not a valid translation");
+
+                if (translationResponse.Count == 0)
+                    throw new InvalidOperationException("No translations were returned");
+
+                var translation = translationResponse.FirstOrDefault()?.Translations?.FirstOrDefault();
+
+                if (translation is null) throw new InvalidOperationException("No translations were returned");
+
+                // Use the auto-detected language if it's present
+                from ??= translationResponse.FirstOrDefault()?.DetectedLanguage?.Language;
+                translated = UnstripText(translation.Text ?? strippedText, inlined, codeBlocks);
             }
-
-            var requestBody = JsonSerializer.Serialize(new[] { new TranslationRequest(strippedText) }, options);
-            var response = await client.PostAsync(url, new StringContent(requestBody, Encoding.UTF8, "application/json"));
-
-            if (!response.IsSuccessStatusCode)
+            catch (Exception ex)
             {
+                _logger.LogCritical(ex, $"Unable to translate message: {ex.Message}");
                 translated = text;
-                var body = await response.Content!.ReadAsStringAsync();
-                throw new InvalidOperationException($"Unable to translate. Service returned {response.StatusCode}: {body}");
             }
-            var json = await response.Content!.ReadAsStringAsync();
-            var translationResponse = JsonSerializer.Deserialize<List<TranslationResponse>>(json, options);
-            translationResponse = translationResponse ?? throw new InvalidOperationException("Response is not a valid translation");
 
-            if (translationResponse.Count == 0)
+            _logger.LogDebug("Finished translating");
+            return new Translation((from ?? "unknown", text), (to, translated));
+        }
+
+        private Dictionary<string, string> StripText(ref string text, Regex pattern)
+        {
+            var replacements = new Dictionary<string, string>();
+
+            text = pattern.Replace(text, str =>
             {
-                throw new InvalidOperationException("No translations were returned");
-            }
-
-            var translation = translationResponse.FirstOrDefault()?.Translations?.FirstOrDefault();
-
-            if (translation is null)
-            {
-                throw new InvalidOperationException("No translations were returned");
-            }
-
-            // Use the auto-detected language if it's present
-            from ??= translationResponse.FirstOrDefault()?.DetectedLanguage?.Language;
-            translated = AddInlinedToString(translation.Text ?? strippedText, inlined);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogCritical(ex, $"Unable to translate message: {ex.Message}");
-            translated = text;
+                var guid = $"{{{keyScrubber.Replace($"{Guid.NewGuid()}", string.Empty)}}}";
+                _logger.LogDebug($"Replacing {str} with {guid}");
+                replacements[guid] = str.Value;
+                return guid;
+            });
+            return replacements;
         }
 
-        _logger.LogDebug("Finished translating");
-        return new Translation((from ?? "unknown", text), (to, translated), codeBlocks);
-    }
-
-    private IEnumerable<string> StripCodeBlocksFromText(ref string text)
-    {
-        var codeBlocks = new List<string>();
-
-        text = codeBlockPattern.Replace(text, str =>
+        private string UnstripText(string text, params Dictionary<string, string>[] replacements)
         {
-            codeBlocks.Add(str.Value);
-            _logger.LogDebug($"Separating code block {str}");
-            return string.Empty;
-        });
-
-        return codeBlocks;
-    }
-
-    private Dictionary<string, string>  StripInlinedFromText(ref string text)
-    {
-        var replacements = new Dictionary<string, string>();
-
-        text = inlinePattern.Replace(text, str =>
-        {
-            var guid = $"{{{keyScrubber.Replace($"{Guid.NewGuid()}", string.Empty)}}}";
-            _logger.LogDebug($"Replacing {str} with {guid}");
-            replacements[guid] = str.Value;
-            return guid;
-        });
-        return replacements;
-    }
-
-    private string AddInlinedToString(string text, Dictionary<string, string> replacements)
-    {
-        var sb = new StringBuilder(text);
-        foreach (var replacement in replacements)
-        {
-            sb.Replace(replacement.Key, replacement.Value);
+            var sb = new StringBuilder(text);
+            foreach (var replacement in replacements)
+            foreach (var r in replacement)
+                sb.Replace(r.Key, r.Value);
+            return sb.ToString();
         }
-        return sb.ToString();
     }
-}
 }


### PR DESCRIPTION
* This now uses the same code as the way inlined code blocks are replaced.
* The message in the history embed and in the channel itself are split into 2048 character chunks